### PR TITLE
Prevent publishing if commit not conform

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 # This file is part of Invenio.
-# 
+#
 #  Copyright (C) 2022 Graz University of Technology.
-# 
+#
 # React-Records-Marc21 is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
@@ -11,7 +11,7 @@ name: Publish
 on:
   push:
     tags:
-      - v*
+      - "*"
 
 jobs:
   Publish:
@@ -19,19 +19,66 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Extract Variables
+        id: vars
+        run: |
+          echo ::set-output name=tag_text::${GITHUB_REF#refs/*/}
+          echo ::set-output name=package_name::${GITHUB_REPOSITORY#*/}
+          echo ::set-output name=message_text::${{ github.event.head_commit.message }}
+
+      - name: Extract Package version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+
+      - name: Check Tag Name
+        run: |
+          if [[ ! ${{ steps.vars.outputs.tag_text }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          then
+              echo "Tag does not follow following convention (v[0-9]+\.[0-9]+\.[0-9]+)!!!"
+              exit 1
+          fi
+
+      - name: Check Commit Message
+        run: |
+          if [[ ! ${{ steps.vars.outputs.message_text }} =~ ^Release\sv[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          then
+              echo "Publish failed: Commit message not conform (Release\sv[0-9]+\.[0-9]+\.[0-9]+)!!!"
+              exit 1
+          fi
+
+      - name: Check Commit Version
+        run: |
+          if [[ ! ${{ steps.vars.outputs.message_text }} == "Release ${{ steps.vars.outputs.tag_text }}" ]]
+          then
+              echo "Publish failed: Commit version not match!!!"
+              echo "Tag: ${{ steps.vars.outputs.tag_text }} Message: ${{ steps.vars.outputs.message_text }}"
+              exit 1
+
+          fi
+
+      - name: Check Package Version
+        run: |
+          if [[ ! "v${{ steps.extract_version.outputs.version }}" == ${{ steps.vars.outputs.tag_text }} ]]
+          then
+              echo "Publish failed: Package version not match!!!"
+              echo "Package version: ${{ steps.extract_version.outputs.version }} Tag version: ${{ steps.vars.outputs.tag_text }}"
+              exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 14
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install and Build
         run: |
           npm install
           npm run build
+
       - name: Publish on NPM
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
publishing a package only if a commit message has the form Release v[0-9]+.[0-9]+.[0-9]+ as well the package version and the tag name have the same semantic version